### PR TITLE
Correct error with zookeeper install tech

### DIFF
--- a/install/download_tech
+++ b/install/download_tech
@@ -19,7 +19,7 @@ SPARK_VER=1.5.2
 SPARK_HADOOP_VER=2.4
 STORM_VER=0.10.0
 TACHYON_VER=0.8.2
-ZOOKEEPER_VER=3.4.7
+ZOOKEEPER_VER=3.4.6
 
 CASSANDRA_URL=http://www.us.apache.org/dist/cassandra/$CASSANDRA_VER/apache-cassandra-$CASSANDRA_VER-bin.tar.gz
 ELASTICSEARCH_URL=https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-$ELASTICSEARCH_VER.tar.gz
@@ -36,7 +36,7 @@ REDIS_URL=http://download.redis.io/releases/redis-$REDIS_VER.tar.gz
 SPARK_URL=http://apache.osuosl.org/spark/spark-$SPARK_VER/spark-$SPARK_VER-bin-hadoop$SPARK_HADOOP_VER.tgz
 STORM_URL=http://www.us.apache.org/dist/storm/apache-storm-$STORM_VER/apache-storm-$STORM_VER.tar.gz
 TACHYON_URL=http://tachyon-project.org/downloads/files/$TACHYON_VER/tachyon-$TACHYON_VER-bin.tar.gz
-ZOOKEEPER_URL=http://www.us.apache.org/dist/zookeeper/stable/zookeeper-$ZOOKEEPER_VER.tar.gz
+ZOOKEEPER_URL=http://www.us.apache.org/dist/zookeeper/zookeeper-$ZOOKEEPER_VER/zookeeper-$ZOOKEEPER_VER.tar.gz
 
 
 if [ "$#" -ne 1 ]; then


### PR DESCRIPTION
ec2install of zookeeper failed due to both non-existent default
Zookeeper version and incorrect URL.  Changed to 3.4.6 and URL should
work for other versions as well now.