### PR TITLE
BF: add pwd to pythonpath at run time to avoid having to 'export PYTHON…

### DIFF
--- a/util/fetch_instances.py
+++ b/util/fetch_instances.py
@@ -1,4 +1,6 @@
 import argparse
+import sys, os
+sys.path.append(os.getcwd())
 from util.boto_util import BotoUtil, remove_cluster_info, write_dns, copy_pem
 
 if __name__ == '__main__':


### PR DESCRIPTION
…PATH=/home/jgors/junk/pegasus' in prior cmdline call since doing nonpkg import.

bugfix to this error:
```
[~/junk/pegasus] (git)-[master]- 
jgors@t450s-linux $ ./ec2fetch us-west-2 jason-web                                                                                  
Traceback (most recent call last):
  File "util/fetch_instances.py", line 12, in <module>
    BUtil = BotoUtil(args.region)
NameError: name 'BotoUtil' is not defined
```