### PR TITLE
Update download_tech to source profile file at the end of install

### DIFF
--- a/install/download_tech
+++ b/install/download_tech
@@ -50,6 +50,7 @@ TECHNOLOGY_URL=$(eval "echo \$$(echo $TECHNOLOGY | tr [a-z] [A-Z])_URL")
 
 check_folder () {
   if [ -d /usr/local/$TECHNOLOGY ]; then
+    source ~/.profile
     echo "$TECHNOLOGY installed."
   else
     echo "$TECHNOLOGY missing."


### PR DESCRIPTION
Adding a source ~/.profile just after the technology is installed. Noticed we have to do this all the time after pegasus runs.