### PR TITLE
Toggle association of EIPs based on AWS_ELASTIC_IPS environment variable.

### DIFF
--- a/util.sh
+++ b/util.sh
@@ -377,14 +377,16 @@ function run_instances {
     tag_resources Role ${role} ${INSTANCE_IDS}
   fi
 
-  for instance_id in ${INSTANCE_IDS}; do
-    association_status=$(allocate_and_associate_eip ${instance_id})
-    if [[ ${association_status} != eipassoc-* ]]; then
-      echo -e "${color_red}Elastic IP not associated with the instance ${instance_id}${color_norm}"
-    else
-      echo -e "${color_green}Elastic IP associated with the instance ${instance_id}${color_norm}"
-    fi
-  done
+  if [ ! -z ${AWS_ELASTIC_IPS} ]; then
+    for instance_id in ${INSTANCE_IDS}; do
+      association_status=$(allocate_and_associate_eip ${instance_id})
+      if [[ ${association_status} != eipassoc-* ]]; then
+        echo -e "${color_red}Elastic IP not associated with the instance ${instance_id}${color_norm}"
+      else
+        echo -e "${color_green}Elastic IP associated with the instance ${instance_id}${color_norm}"
+      fi
+    done
+  fi
 }
 
 function check_remote_folder {


### PR DESCRIPTION
In our AWS account, we don't have many EIPs available to us -- they are all in use.  So, having Pegasus automatically try to associate an EIP to every node in the cluster doesn't work.  We only have say 5 EIPs available and we want a 20-node spark cluster.  The way the Pegasus code is currently written, it tries to associate an EIP to each node and as soon as we run out of EIPs, we get errors.

As a quick hack, I wrapped that section in code with a check for an environment variable being defined named ```AWS_ELASTIC_IPS```.  If it's defined, then it will run the EIP association code, otherwise it will skip it.
