### PR TITLE
added eips and spot instance to the default yaml config

### DIFF
--- a/defaults.yml
+++ b/defaults.yml
@@ -1,1 +1,4 @@
 vol_type: standard
+purchase_type: spot
+price: 0.13
+use_eips: true


### PR DESCRIPTION
These could be used as defaults, which would optimize on cost and also clean up the custom config yamls in the examples.