### PR TITLE
added peg root path to default

### DIFF
--- a/util.sh
+++ b/util.sh
@@ -271,7 +271,7 @@ function describe_cluster {
 
 function set_launch_config {
   local template_file=$1
-  eval $(parse_yaml ${DEFAULT_TEMPLATE_FILE})
+  eval $(parse_yaml ${PEG_ROOT}/${DEFAULT_TEMPLATE_FILE})
   eval $(parse_yaml ${template_file})
 }
 


### PR DESCRIPTION
When peg is called outside of the pegasus project, the default.yml is not read with the right path. Added in the $PEG_ROOT when reading default.yml