### PR TITLE
deprecation edits: removed advertised.hostname and added advertised.l…

### DIFF
--- a/config/kafka/setup_single.sh
+++ b/config/kafka/setup_single.sh
@@ -22,7 +22,8 @@ DNS=( "$@" )
 . ~/.profile
 
 sudo sed -i 's@broker.id=0@broker.id='"$ID"'@g' /usr/local/kafka/config/server.properties
-sudo sed -i 's@#advertised.host.name=<hostname routable by clients>@advertised.host.name='"$PUBLIC_DNS"'@g' /usr/local/kafka/config/server.properties
+sudo sed -i 's@#advertised.listeners=PLAINTEXT://your.host.name@advertised.listeners=PLAINTEXT://'"$PUBLIC_DNS"'@g' /usr/local/kafka/config/server.properties
+
 sudo sed -i '1i export JMX_PORT=${JMX_PORT:-9999}' /usr/local/kafka/bin/kafka-server-start.sh
 
 ZK_SERVERS=""


### PR DESCRIPTION
There's a bug in the kafka install that doesn't allow you from your laptop to push messages to a kafka broker. The Single_setup.sh script for Kafka installation is trying to do a sed on a deprecated property (advertised.hostnames) that is no longer in the server.properties file. I changed the sed to change (advertised.listeners). I'll go ahead and tell people to use this branch if they are interested in getting this fix so as to test it some more before merging to master. 
