### PR TITLE
Fix ssh-agent check to use $SSH_AGENT_PID and $SSH_AUTH_SOCK instead …

### DIFF
--- a/util.sh
+++ b/util.sh
@@ -228,9 +228,10 @@ function store_pemkey {
   chmod 400 ~/.ssh/${unique_pemkeys}.pem
 
   cp ~/.ssh/${unique_pemkeys}.pem ${PEG_ROOT}/tmp/${cluster_name}
-
-  sshagent_pid_cnt=$(pgrep ssh-agent | wc -l)
-  if [ "${sshagent_pid_cnt}" -ne "0" ]; then
+  if [ $SSH_AGENT_PID ]; then
+    if ! [ $SSH_AUTH_SOCK ]; then
+        eval $(ssh-agent -s)
+    fi
     ssh-add ${PEG_ROOT}/tmp/${cluster_name}/${unique_pemkeys}.pem > /dev/null 2>&1
     echo "${unique_pemkeys}.pem has been added to your ssh-agent"
   else


### PR DESCRIPTION
Fix ssh-agent check to use $SSH_AGENT_PID and $SSH_AUTH_SOCK instead of counting the number of ssh-agent instances.